### PR TITLE
Add Create Identifier action

### DIFF
--- a/Civi/Identitytracker/Actions/CreateIdentifier.php
+++ b/Civi/Identitytracker/Actions/CreateIdentifier.php
@@ -1,0 +1,74 @@
+<?php
+namespace Civi\Identitytracker\Actions;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use Civi\ActionProvider\Exception\ExecutionException;
+use \Civi\ActionProvider\Exception\InvalidParameterException;
+use Civi\ActionProvider\Parameter\OptionGroupByNameSpecification;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+use \Civi\ActionProvider\Parameter\Specification;
+
+use Civi\Core\Lock\NullLock;
+use Civi\FormProcessor\API\Exception;
+use CRM_Identitytracker_ExtensionUtil as E;
+
+/**
+ * Class to create a new contact identifier (for usage in action-provider/form-processor)
+ *
+ * @package Civi\Identitytracker\Actions
+ * @author Erik Hommel (CiviCooP) <erik.hommel@civicoop.org>
+ * @license AGPL-3.0
+ */
+class CreateIdentifier extends AbstractAction {
+
+  /**
+   * @return SpecificationBag
+   */
+  public function getParameterSpecification() {
+    $specs = new SpecificationBag();
+    $specs->addSpecification(new Specification('contact_id', 'Integer', E::ts('Contact ID'), TRUE, NULL));
+    $specs->addSpecification(new Specification('identifier', 'String', E::ts('Contact Identifier'), TRUE, NULL));
+    return $specs;
+  }
+
+  /**
+   * @return SpecificationBag
+   */
+  public function getConfigurationSpecification() {
+    $specs = new SpecificationBag();
+    $specs->addSpecification(new OptionGroupByNameSpecification('identifier_type', 'contact_id_history_type', E::ts('Contact Identity Type'), TRUE));
+    return $specs;
+  }
+
+  /**
+   * Do the actual action - add identifier to contact
+   *
+   * @param ParameterBagInterface $parameters
+   * @param ParameterBagInterface $output
+   * @throws ExecutionException
+   */
+  public function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    try {
+      civicrm_api3('Contact', 'addidentity', [
+        'contact_id' => $parameters->getParameter('contact_id'),
+        'identifier' => $parameters->getParameter('identifier'),
+        'identifier_type' => $this->configuration->getParameter('identifier_type'),
+      ]);
+    }
+    catch (\CiviCRM_API3_Exception $ex) {
+      throw new ExecutionException(E::ts('Error in API Contact addidentity with message: ') . $ex->getMessage());
+    }
+  }
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overriden by child classes.
+   *
+   * @return SpecificationBag
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag();
+  }
+
+}

--- a/Civi/Identitytracker/Actions/CreateIdentifier.php
+++ b/Civi/Identitytracker/Actions/CreateIdentifier.php
@@ -10,7 +10,6 @@ use \Civi\ActionProvider\Parameter\SpecificationBag;
 use \Civi\ActionProvider\Parameter\Specification;
 
 use Civi\Core\Lock\NullLock;
-use Civi\FormProcessor\API\Exception;
 use CRM_Identitytracker_ExtensionUtil as E;
 
 /**
@@ -49,11 +48,12 @@ class CreateIdentifier extends AbstractAction {
    * @throws ExecutionException
    */
   public function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $type = $this->configuration->getParameter('identifier_type');
     try {
       civicrm_api3('Contact', 'addidentity', [
         'contact_id' => $parameters->getParameter('contact_id'),
         'identifier' => $parameters->getParameter('identifier'),
-        'identifier_type' => $this->configuration->getParameter('identifier_type'),
+        'identifier_type' => $type,
       ]);
     }
     catch (\CiviCRM_API3_Exception $ex) {

--- a/Civi/Identitytracker/CompilerPass.php
+++ b/Civi/Identitytracker/CompilerPass.php
@@ -1,0 +1,21 @@
+<?php
+namespace Civi\Identitytracker;
+
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use CRM_Identitytracker_ExtensionUtil as E;
+
+/**
+ * Compiler Class for action provider
+ */
+class CompilerPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container) {
+    if ($container->hasDefinition('action_provider')) {
+      $actionProviderDefinition = $container->getDefinition('action_provider');
+      $actionProviderDefinition->addMethodCall('addAction',
+        ['CreateIdentifier', 'Civi\Identitytracker\Actions\CreateIdentifier', E::ts('Create Contact Identity'), []]);
+    }
+  }
+}

--- a/identitytracker.php
+++ b/identitytracker.php
@@ -13,8 +13,17 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
-
 require_once 'identitytracker.civix.php';
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Implements hook_civicrm_container().
+ *
+ * @param ContainerBuilder $container
+ */
+function identitytracker_civicrm_container(ContainerBuilder $container) {
+  $container->addCompilerPass(new Civi\Identitytracker\CompilerPass());
+}
 
 /**
  * implement this hook to make sure we capture all ID changes
@@ -53,7 +62,7 @@ function identitytracker_civicrm_post( $op, $objectName, $objectId, &$objectRef 
 }
 
 /**
- * if custom fields that are identities are written, 
+ * if custom fields that are identities are written,
  *  make sure we copy the value into the identity table
  */
 function identitytracker_civicrm_custom($op, $groupID, $entityID, &$params) {

--- a/info.xml
+++ b/info.xml
@@ -23,6 +23,9 @@
     <ver>5.0</ver>
     <ver>5.5</ver>
   </compatibility>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi" />
+  </classloader>
   <comments>This extension has initially been funded by Amnesty International Vlaanderen</comments>
   <civix>
     <namespace>CRM/Identitytracker</namespace>


### PR DESCRIPTION
This PR adds the Form Processor / Action Provider action Create Identfier. It is required for Amnesty but generically interesting. I tested it locally.