### PR TITLE
Move identity migration to `postIntall` step

### DIFF
--- a/identitytracker.php
+++ b/identitytracker.php
@@ -93,16 +93,6 @@ function identitytracker_civicrm_custom($op, $groupID, $entityID, &$params) {
  */
 function identitytracker_civicrm_enable() {
   _identitytracker_civix_civicrm_enable();
-
-  // register the IndentiyAnalyser if CiviBanking is installed
-  CRM_Identitytracker_Configuration::registerIdentityAnalyser();
-
-  // then see if we need to migrate old data
-  CRM_Core_Error::debug_log_message("de.systopia.identitytracker: Migrating internal contact IDs...");
-  CRM_Identitytracker_Migration::migrateInternal();
-  CRM_Core_Error::debug_log_message("de.systopia.identitytracker: Migrating external contact IDs...");
-  CRM_Identitytracker_Migration::migrateExternal();
-  CRM_Core_Error::debug_log_message("de.systopia.identitytracker: Migration completed.");
 }
 
 /**


### PR DESCRIPTION
The code needs the managed entities to exist so it cannot run on `enable`.

I've also dropped the comment `then see if we need to migrate old data` as it misleads to the impression that it is about data from previous versions of the extension.

Fixes #19.