### PR TITLE
Incompatible with CiviCRM Core 5.71 - Use correct joins for multi-value custom group

### DIFF
--- a/api/v3/Contact/Findbyidentity.php
+++ b/api/v3/Contact/Findbyidentity.php
@@ -21,13 +21,18 @@ use \Civi\Api4\Contact;
 function civicrm_api3_contact_findbyidentity($params) {
   $query = Contact::get(FALSE)
     ->addSelect('id')
-    ->addWhere(CRM_Identitytracker_Configuration::GROUP_NAME . '.' . CRM_Identitytracker_Configuration::TYPE_FIELD_NAME, '=', $params['identifier_type'])
-    ->addWhere(CRM_Identitytracker_Configuration::GROUP_NAME . '.' . CRM_Identitytracker_Configuration::ID_FIELD_NAME, '=', $params['identifier'])
+    ->addJoin(
+      'Custom_' . CRM_Identitytracker_Configuration::GROUP_NAME . ' AS custom_contact_id_history',
+      'INNER',
+      ['custom_contact_id_history.entity_id', '=', 'id']
+    )
+    ->addWhere('custom_contact_id_history.' . CRM_Identitytracker_Configuration::TYPE_FIELD_NAME, '=', $params['identifier_type'])
+    ->addWhere('custom_contact_id_history.' . CRM_Identitytracker_Configuration::ID_FIELD_NAME, '=', $params['identifier'])
     ->addWhere('is_deleted', '=', FALSE)
     ->addGroupBy('id');
 
   if (isset($params['context'])) {
-    $query->addWhere(CRM_Identitytracker_Configuration::GROUP_NAME . '.' . CRM_Identitytracker_Configuration::CONTEXT_FIELD_NAME, '=', $params['context']);
+    $query->addWhere('custom_contact_id_history.' . CRM_Identitytracker_Configuration::CONTEXT_FIELD_NAME, '=', $params['context']);
   }
 
   $results = $query


### PR DESCRIPTION
The current method of adding conditions for fields in the multi-value custom group does not work with CiviCRM 5.71 anymore. There should be correct explicit joins for making the custom fields available for adding as `where` conditions.

> [!CAUTION]
> This needs tests on CiviCRM < `5.71` to ensure backwards-compatibility or the minimum required CiviCRM Core version increased to `5.71`.

This fixes error messages like the following when calling the extensions's `Contact.identify` API3 action:
```
"Invalid field 'contact_id_history.id_history_entry_type'"
```

*systopia-reference: 24341*