### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Identitytracker/CustomData.php
+++ b/CRM/Identitytracker/CustomData.php
@@ -735,7 +735,7 @@ class CRM_Identitytracker_CustomData {
         return $field_data['value'];
       } else {
         // unlikely, but worth a shot:
-        return CRM_Utils_Array::value("custom_{$field_id}", $params, NULL);
+        return $params["custom_{$field_id}"] ?? NULL;
       }
     }
     return NULL;
@@ -785,9 +785,9 @@ class CRM_Identitytracker_CustomData {
           'value'           => $value,
           'type'            => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
           'custom_field_id' => $field_id,
-          'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, NULL),
-          'table_name'      => CRM_Utils_Array::value('table_name', $group_specs, NULL),
-          'column_name'     => CRM_Utils_Array::value('column_name', $field_specs, NULL),
+          'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+          'table_name'      => $group_specs['table_name'] ?? NULL,
+          'column_name'     => $field_specs['column_name'] ?? NULL,
           'is_multiple'     => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
       ];
     } else {

--- a/CRM/Identitytracker/Form/Settings.php
+++ b/CRM/Identitytracker/Form/Settings.php
@@ -103,8 +103,8 @@ class CRM_Identitytracker_Form_Settings extends CRM_Core_Form {
     // store
     $mapping = array();
     for ($i=0; $i <= self::CUSTOM_FIELD_COUNT; $i++) {
-      $custom_field  = CRM_Utils_Array::value("custom_field_$i", $values, NULL);
-      $identity_type = CRM_Utils_Array::value("identity_type_$i", $values, NULL);
+      $custom_field  = $values["custom_field_$i"] ?? NULL;
+      $identity_type = $values["identity_type_$i"] ?? NULL;
       if (!empty($custom_field) && !empty($identity_type)) {
         $mapping[$custom_field] = $identity_type;
       }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.