### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Identitytracker/Configuration.php
+++ b/CRM/Identitytracker/Configuration.php
@@ -193,7 +193,7 @@ class CRM_Identitytracker_Configuration {
    * Checks it an $option_value already exists, and if not create it
    * @param $option_type
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function add_identity_type($option_type, $option_label)
   {

--- a/Civi/Identitytracker/Actions/CreateIdentifier.php
+++ b/Civi/Identitytracker/Actions/CreateIdentifier.php
@@ -56,7 +56,7 @@ class CreateIdentifier extends AbstractAction {
         'identifier_type' => $type,
       ]);
     }
-    catch (\CiviCRM_API3_Exception $ex) {
+    catch (\CRM_Core_Exception $ex) {
       throw new ExecutionException(E::ts('Error in API Contact addidentity with message: ') . $ex->getMessage());
     }
   }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.