### PR TITLE
Add return type hint to `CompilerPass::process()` for Symfony 8 compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -112,6 +112,7 @@ jobs:
         export CV_CONFIG="$HOME/.cv.json"
         cv vars:fill --quiet
         sed -i "s#\"TEST_DB_DSN\": \".*\"#\"TEST_DB_DSN\": \"$DATABASE_URL\"#g" "$CV_CONFIG"
+        cv en civi_contribute
 
         cv ext:download "action-provider@https://lab.civicrm.org/extensions/action-provider/-/archive/1.195/action-provider-1.195.zip"
         cv ext:download "org.project60.banking@https://github.com/Project60/org.project60.banking/releases/download/1.4.1/org.project60.banking-1.4.1.zip"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -114,7 +114,7 @@ jobs:
         sed -i "s#\"TEST_DB_DSN\": \".*\"#\"TEST_DB_DSN\": \"$DATABASE_URL\"#g" "$CV_CONFIG"
 
         cv ext:download "action-provider@https://lab.civicrm.org/extensions/action-provider/-/archive/1.195/action-provider-1.195.zip"
-        cv ext:download "org.project60.banking@https://github.com/Project60/org.project60.banking/releases/download/1.3.2/org.project60.banking-1.3.2.zip"
+        cv ext:download "org.project60.banking@https://github.com/Project60/org.project60.banking/releases/download/1.4.1/org.project60.banking-1.4.1.zip"
         cv ext:download "de.systopia.xcm@https://github.com/systopia/de.systopia.xcm/releases/download/1.14.1/de.systopia.xcm-1.14.1.zip"
 
     - name: Run PHPUnit

--- a/Civi/Identitytracker/CompilerPass.php
+++ b/Civi/Identitytracker/CompilerPass.php
@@ -16,7 +16,7 @@ class CompilerPass implements CompilerPassInterface {
   /**
    * @inheritDoc
    */
-  public function process(ContainerBuilder $container) {
+  public function process(ContainerBuilder $container): void {
     if ($container->hasDefinition('action_provider')) {
       $actionProviderDefinition = $container->getDefinition('action_provider');
       $actionProviderDefinition->addMethodCall('addAction',


### PR DESCRIPTION
In Symfony 8 the PHP return type hint `void` was added to [\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()](https://github.com/symfony/dependency-injection/blob/8.0/Compiler/CompilerPassInterface.php).