### PR TITLE
Add return type declaration for process() method

### DIFF
--- a/Civi/Identitytracker/CompilerPass.php
+++ b/Civi/Identitytracker/CompilerPass.php
@@ -16,7 +16,7 @@ class CompilerPass implements CompilerPassInterface {
   /**
    * @inheritDoc
    */
-  public function process(ContainerBuilder $container) {
+  public function process(ContainerBuilder $container): void {
     if ($container->hasDefinition('action_provider')) {
       $actionProviderDefinition = $container->getDefinition('action_provider');
       $actionProviderDefinition->addMethodCall('addAction',


### PR DESCRIPTION
The declaration of the `Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()` method expects `void` as return type.

Without the return type, PhpUnit workflows of extensions that depend on `de.systopia.identitytracker` will [fail](https://github.com/systopia/funding/actions/runs/27615675274/job/81650876163?pr=610#step:10:18).